### PR TITLE
Non compat products

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+     "editor.tabSize": 4
+}

--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ Say bye bye to the relative path hell!
 | Arg | Type | Description | Default |
 |--------|------|-------------|---------|
 | `-f` | `boolean` | `optional` - skip the confirmation prompt displayed before `tspath` parses the project (e.g. `tspath -f`) | `false` |
+| `-c` | `boolean` | `optional` - do not include superfluous whitespace characters and line terminators (e.g. `tspath -c`) | `false` |

--- a/README.md
+++ b/README.md
@@ -72,3 +72,10 @@ Yes, that´s it, really!
 
 
 Say bye bye to the relative path hell!
+
+#### Options
+
+
+| Arg | Type | Description | Default |
+|--------|------|-------------|---------|
+| `-f` | `boolean` | `optional` - skip the confirmation prompt displayed before `tspath` parses the project (e.g. `tspath -f`) | `false` |

--- a/dist/src/parser-engine.js
+++ b/dist/src/parser-engine.js
@@ -33,6 +33,7 @@ const json_comment_stripper_1 = require("./json-comment-stripper");
 const project_options_1 = require("./project-options");
 const type_definitions_1 = require("./type-definitions");
 const type_definitions_2 = require("./type-definitions");
+const tspath_1 = require("./tspath");
 const log = console.log;
 class ParserEngine {
     constructor() {
@@ -178,7 +179,9 @@ class ParserEngine {
                 node.arguments[0] = scope.processJsRequire(node.arguments[0], filename);
             }
         });
-        let option = { comment: true, format: { compact: true, quotes: '"' } };
+        let option = { comment: true };
+        if (tspath_1.TSPath.parseCommandLineParam("-c"))
+            option['format'] = { compact: true, quotes: '"' };
         let finalSource = escodegen.generate(ast, option);
         try {
             this.saveFileContents(filename, finalSource);

--- a/dist/src/parser-engine.js
+++ b/dist/src/parser-engine.js
@@ -95,8 +95,7 @@ class ParserEngine {
         else {
             log(chalk.yellow.bold("Parsing project at: ") + '"' + this.projectPath + '"');
         }
-        this.appRoot = path.resolve(this.projectPath, this.projectOptions.baseUrl);
-        this.appRoot = path.resolve(this.appRoot, this.projectOptions.outDir);
+        this.appRoot = path.resolve(this.projectPath, this.projectOptions.outDir);
         let fileList = new Array();
         this.walkSync(this.appRoot, fileList, ".js");
         for (var i = 0; i < fileList.length; i++) {

--- a/dist/src/tspath.d.ts
+++ b/dist/src/tspath.d.ts
@@ -2,5 +2,5 @@ export declare class TSPath {
     private engine;
     constructor();
     private processPath(projectPath);
-    parseCommandLineParam(): string;
+    static parseCommandLineParam(id: string): string;
 }

--- a/dist/src/tspath.js
+++ b/dist/src/tspath.js
@@ -14,12 +14,11 @@ class TSPath {
     constructor() {
         this.engine = new parser_engine_1.ParserEngine();
         log(chalk.yellow("TSPath " + pkg.version));
-        let args = process.argv.slice(2);
-        let param = args[0];
+        let param = TSPath.parseCommandLineParam("-f");
         let projectPath = process.cwd();
         let findResult = parent_file_finder_1.ParentFileFinder.findFile(projectPath, type_definitions_1.TS_CONFIG);
         var scope = this;
-        if (param == "-f" && findResult.fileFound) {
+        if (param && findResult.fileFound) {
             scope.processPath(findResult.path);
         }
         else if (findResult.fileFound) {
@@ -39,12 +38,17 @@ class TSPath {
             this.engine.execute();
         }
     }
-    parseCommandLineParam() {
+    static parseCommandLineParam(id) {
         let args = process.argv.slice(2);
         var param = null;
-        if (args.length != 1) {
-            param = args[0];
+        const argsLen = args.length;
+        let counter = 0;
+        while (param === null && counter < argsLen) {
+            if (args[counter] === id)
+                param = args[counter];
+            counter++;
         }
+        ;
         return param;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,29 @@
 {
-  "name": "tspath",
-  "version": "0.7.2",
+  "name": "@coldmind/tspath",
+  "version": "0.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/chai": {
-      "version": "https://registry.npmjs.org/@types/chai/-/chai-4.0.4.tgz",
-      "integrity": "sha1-/oYxXZpmgn/usW9zvJVGiOyVDhg=",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.4.tgz",
+      "integrity": "sha512-h6+VEw2Vr3ORiFCyyJmcho2zALnUq9cvdB/IO8Xs9itrJVCenC7o26A6+m7D0ihTTr65eS259H5/Ghl/VjYs6g==",
       "dev": true
     },
     "@types/mocha": {
-      "version": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.42.tgz",
-      "integrity": "sha1-q3afUdN2Rrb+jUoIapjChbH6s/U=",
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
       "dev": true
     },
     "@types/node": {
-      "version": "https://registry.npmjs.org/@types/node/-/node-8.0.26.tgz",
-      "integrity": "sha1-TVi+klMG/SKxFBCFU1oCaLi+sYk="
+      "version": "8.10.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.23.tgz",
+      "integrity": "sha512-aEp5ZTLr4mYhR9S85cJ+sEYkcsgFY10N1Si5m49iTAVzanZXOwp/pgw6ibFLKXxpflqm71aSWZCRtnTXXO56gA=="
     },
     "amdefine": {
-      "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "optional": true
     },
@@ -116,33 +120,33 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
       "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
       "requires": {
-        "ansi-bgblack": "0.1.1",
-        "ansi-bgblue": "0.1.1",
-        "ansi-bgcyan": "0.1.1",
-        "ansi-bggreen": "0.1.1",
-        "ansi-bgmagenta": "0.1.1",
-        "ansi-bgred": "0.1.1",
-        "ansi-bgwhite": "0.1.1",
-        "ansi-bgyellow": "0.1.1",
-        "ansi-black": "0.1.1",
-        "ansi-blue": "0.1.1",
-        "ansi-bold": "0.1.1",
-        "ansi-cyan": "0.1.1",
-        "ansi-dim": "0.1.1",
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "ansi-grey": "0.1.1",
-        "ansi-hidden": "0.1.1",
-        "ansi-inverse": "0.1.1",
-        "ansi-italic": "0.1.1",
-        "ansi-magenta": "0.1.1",
-        "ansi-red": "0.1.1",
-        "ansi-reset": "0.1.1",
-        "ansi-strikethrough": "0.1.1",
-        "ansi-underline": "0.1.1",
-        "ansi-white": "0.1.1",
-        "ansi-yellow": "0.1.1",
-        "lazy-cache": "2.0.2"
+        "ansi-bgblack": "^0.1.1",
+        "ansi-bgblue": "^0.1.1",
+        "ansi-bgcyan": "^0.1.1",
+        "ansi-bggreen": "^0.1.1",
+        "ansi-bgmagenta": "^0.1.1",
+        "ansi-bgred": "^0.1.1",
+        "ansi-bgwhite": "^0.1.1",
+        "ansi-bgyellow": "^0.1.1",
+        "ansi-black": "^0.1.1",
+        "ansi-blue": "^0.1.1",
+        "ansi-bold": "^0.1.1",
+        "ansi-cyan": "^0.1.1",
+        "ansi-dim": "^0.1.1",
+        "ansi-gray": "^0.1.1",
+        "ansi-green": "^0.1.1",
+        "ansi-grey": "^0.1.1",
+        "ansi-hidden": "^0.1.1",
+        "ansi-inverse": "^0.1.1",
+        "ansi-italic": "^0.1.1",
+        "ansi-magenta": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "ansi-reset": "^0.1.1",
+        "ansi-strikethrough": "^0.1.1",
+        "ansi-underline": "^0.1.1",
+        "ansi-white": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "lazy-cache": "^2.0.1"
       }
     },
     "ansi-cyan": {
@@ -247,10 +251,11 @@
       }
     },
     "ansi-styles": {
-      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "^1.9.0"
       }
     },
     "ansi-underline": {
@@ -292,49 +297,55 @@
       "resolved": "https://registry.npmjs.org/arr-swap/-/arr-swap-1.0.1.tgz",
       "integrity": "sha1-FHWQ7WX8gVvAf+8Jl8Llgj1kNTQ=",
       "requires": {
-        "is-number": "3.0.0"
+        "is-number": "^3.0.0"
       }
     },
     "arrify": {
-      "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "assertion-error": {
-      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "browser-stdout": {
-      "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
     "chai": {
-      "version": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-        "check-error": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.0.tgz",
-        "get-func-name": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-        "pathval": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -342,9 +353,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
       "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "requires": {
-        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "supports-color": "4.5.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -357,13 +368,14 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
     },
     "check-error": {
-      "version": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
@@ -372,9 +384,9 @@
       "resolved": "https://registry.npmjs.org/choices-separator/-/choices-separator-2.0.0.tgz",
       "integrity": "sha1-kv0XYxgteQM/XFxR0Lo1LlVnxpY=",
       "requires": {
-        "ansi-dim": "0.1.1",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "strip-color": "0.1.0"
+        "ansi-dim": "^0.1.1",
+        "debug": "^2.6.6",
+        "strip-color": "^0.1.0"
       }
     },
     "clone-deep": {
@@ -382,10 +394,10 @@
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-1.0.0.tgz",
       "integrity": "sha512-hmJRX8x1QOJVV+GUjOBzi6iauhPqc9hIF6xitWRBbiPZOBb6vGo/mDRIK9P74RTKSQK7AE8B0DDWY/vpRrPmQw==",
       "requires": {
-        "for-own": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "5.1.0",
-        "shallow-clone": "1.0.0"
+        "for-own": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^5.0.0",
+        "shallow-clone": "^1.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -400,8 +412,8 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -409,7 +421,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -423,7 +435,8 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -433,22 +446,25 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "debug": {
-      "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "requires": {
-        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+        "ms": "2.0.0"
       }
     },
     "deep-eql": {
-      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.0.tgz",
       "integrity": "sha1-uRYqSc9LVNkRQll1rJXQPlZEhHE=",
       "dev": true,
       "requires": {
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
-      "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "define-property": {
@@ -456,11 +472,12 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
       "requires": {
-        "is-descriptor": "1.0.1"
+        "is-descriptor": "^1.0.0"
       }
     },
     "diff": {
-      "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
@@ -470,36 +487,42 @@
       "integrity": "sha1-Ck2uN9YA0VopukU9jvkg8YRDM/Y="
     },
     "escape-string-regexp": {
-      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "requires": {
-        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "esprima": {
-          "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
           "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
         }
       }
     },
     "esprima": {
-      "version": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
     },
     "estraverse": {
-      "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
       "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
     },
     "esutils": {
-      "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "extend-shallow": {
@@ -507,11 +530,12 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "fast-levenshtein": {
-      "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "for-in": {
@@ -524,54 +548,61 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "get-func-name": {
-      "version": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "dev": true,
       "requires": {
-        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
-      "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
     "has-flag": {
-      "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "info-symbol": {
@@ -580,7 +611,8 @@
       "integrity": "sha1-J4QdcoZ920JCzWEtecEGM4gcang="
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
@@ -589,7 +621,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-buffer": {
@@ -602,7 +634,7 @@
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-descriptor": {
@@ -610,9 +642,9 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.1.tgz",
       "integrity": "sha512-G3fFVFTqfaqu7r4YuSBHKBAuOaLz8Sy7ekklUpFEliaLMP1Y2ZjoN9jS62YWCAPQrQpMUQSitRlrzibbuCZjdA==",
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -637,7 +669,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-plain-object": {
@@ -645,7 +677,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-windows": {
@@ -659,7 +691,8 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "json3": {
-      "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
@@ -668,7 +701,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "koalas": {
@@ -681,74 +714,84 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "requires": {
-        "set-getter": "0.1.0"
+        "set-getter": "^0.1.0"
       }
     },
     "levn": {
-      "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash._baseassign": {
-      "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
-      "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
-      "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
-      "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
-      "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.create": {
-      "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-        "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.isarguments": {
-      "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
-      "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.keys": {
-      "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "log-ok": {
@@ -756,8 +799,8 @@
       "resolved": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
       "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
       "requires": {
-        "ansi-green": "0.1.1",
-        "success-symbol": "0.1.0"
+        "ansi-green": "^0.1.1",
+        "success-symbol": "^0.1.0"
       }
     },
     "log-utils": {
@@ -765,17 +808,18 @@
       "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
       "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
       "requires": {
-        "ansi-colors": "0.2.0",
-        "error-symbol": "0.1.0",
-        "info-symbol": "0.1.0",
-        "log-ok": "0.1.1",
-        "success-symbol": "0.1.0",
-        "time-stamp": "1.1.0",
-        "warning-symbol": "0.1.0"
+        "ansi-colors": "^0.2.0",
+        "error-symbol": "^0.1.0",
+        "info-symbol": "^0.1.0",
+        "log-ok": "^0.1.1",
+        "success-symbol": "^0.1.0",
+        "time-stamp": "^1.0.1",
+        "warning-symbol": "^0.1.0"
       }
     },
     "make-error": {
-      "version": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
       "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
       "dev": true
     },
@@ -784,19 +828,21 @@
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -805,8 +851,8 @@
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -817,43 +863,47 @@
       }
     },
     "mkdirp": {
-      "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        "minimist": "0.0.8"
       }
     },
     "mocha": {
-      "version": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
       "integrity": "sha1-EyhWfScX+ZcDD4AGI0vOm4zXJGU=",
       "dev": true,
       "requires": {
-        "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-        "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
       },
       "dependencies": {
         "commander": {
-          "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            "graceful-readlink": ">= 1.0.0"
           }
         }
       }
     },
     "ms": {
-      "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
@@ -866,9 +916,9 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -876,7 +926,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-descriptor": {
@@ -884,9 +934,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -903,36 +953,40 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        "wrappy": "1"
       }
     },
     "optionator": {
-      "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "pathval": {
-      "version": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
@@ -942,7 +996,8 @@
       "integrity": "sha1-YPkRAgTqepKbYmRKITFVQ8uz1Ec="
     },
     "prelude-ls": {
-      "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prompt-actions": {
@@ -950,7 +1005,7 @@
       "resolved": "https://registry.npmjs.org/prompt-actions/-/prompt-actions-3.0.2.tgz",
       "integrity": "sha512-dhz2Fl7vK+LPpmnQ/S/eSut4BnH4NZDLyddHKi5uTU/2PDn3grEMGkgsll16V5RpVUh/yxdiam0xsM0RD4xvtg==",
       "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+        "debug": "^2.6.8"
       }
     },
     "prompt-base": {
@@ -958,15 +1013,15 @@
       "resolved": "https://registry.npmjs.org/prompt-base/-/prompt-base-4.1.0.tgz",
       "integrity": "sha512-svGzgLUKZoqomz9SGMkf1hBG8Wl3K7JGuRCXc/Pv7xw8239hhaTBXrmjt7EXA9P/QZzdyT8uNWt9F/iJTXq75g==",
       "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "koalas": "1.0.2",
-        "log-utils": "0.2.1",
-        "prompt-actions": "3.0.2",
-        "prompt-question": "5.0.2",
-        "readline-ui": "2.2.3",
-        "readline-utils": "2.2.3",
-        "static-extend": "0.1.2"
+        "component-emitter": "^1.2.1",
+        "debug": "^3.0.1",
+        "koalas": "^1.0.2",
+        "log-utils": "^0.2.1",
+        "prompt-actions": "^3.0.2",
+        "prompt-question": "^5.0.1",
+        "readline-ui": "^2.2.3",
+        "readline-utils": "^2.2.3",
+        "static-extend": "^0.1.2"
       },
       "dependencies": {
         "debug": {
@@ -974,7 +1029,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            "ms": "2.0.0"
           }
         }
       }
@@ -984,25 +1039,25 @@
       "resolved": "https://registry.npmjs.org/prompt-choices/-/prompt-choices-4.0.5.tgz",
       "integrity": "sha512-BwdffZWNx2WYAu+rOcAxg1qGrZYSqC+DTWlZRMFHK3DC1ROHE+fFXx7qJwxsirSVrLnn9PUC9fqmMFg8vU0oTw==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "arr-swap": "1.0.1",
-        "choices-separator": "2.0.0",
-        "clone-deep": "1.0.0",
-        "collection-visit": "1.0.0",
-        "debug": "3.1.0",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "kind-of": "5.1.0",
-        "koalas": "1.0.2",
-        "lazy-cache": "2.0.2",
-        "log-utils": "0.2.1",
-        "pointer-symbol": "1.0.0",
-        "radio-symbol": "2.0.0",
-        "set-value": "2.0.0",
-        "strip-color": "0.1.0",
-        "terminal-paginator": "2.0.2",
-        "toggle-array": "1.0.1"
+        "arr-flatten": "^1.1.0",
+        "arr-swap": "^1.0.1",
+        "choices-separator": "^2.0.0",
+        "clone-deep": "^1.0.0",
+        "collection-visit": "^1.0.0",
+        "debug": "^3.0.1",
+        "define-property": "^1.0.0",
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "kind-of": "^5.0.2",
+        "koalas": "^1.0.2",
+        "lazy-cache": "^2.0.2",
+        "log-utils": "^0.2.1",
+        "pointer-symbol": "^1.0.0",
+        "radio-symbol": "^2.0.0",
+        "set-value": "^2.0.0",
+        "strip-color": "^0.1.0",
+        "terminal-paginator": "^2.0.2",
+        "toggle-array": "^1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -1010,7 +1065,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            "ms": "2.0.0"
           }
         },
         "kind-of": {
@@ -1025,8 +1080,8 @@
       "resolved": "https://registry.npmjs.org/prompt-confirm/-/prompt-confirm-1.2.0.tgz",
       "integrity": "sha512-r7XZxI5J5/oPtUskN0ZYO+lkv/WJHMQgfd1GTKAuxnHuViQShiFHdUnj6DamL4gQExaKAX7rnIcTKoRSpVVquA==",
       "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "prompt-base": "4.1.0"
+        "debug": "^2.6.8",
+        "prompt-base": "^4.0.1"
       }
     },
     "prompt-question": {
@@ -1034,13 +1089,13 @@
       "resolved": "https://registry.npmjs.org/prompt-question/-/prompt-question-5.0.2.tgz",
       "integrity": "sha512-wreaLbbu8f5+7zXds199uiT11Ojp59Z4iBi6hONlSLtsKGTvL2UY8VglcxQ3t/X4qWIxsNCg6aT4O8keO65v6Q==",
       "requires": {
-        "clone-deep": "1.0.0",
-        "debug": "3.1.0",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "kind-of": "5.1.0",
-        "koalas": "1.0.2",
-        "prompt-choices": "4.0.5"
+        "clone-deep": "^1.0.0",
+        "debug": "^3.0.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "kind-of": "^5.0.2",
+        "koalas": "^1.0.2",
+        "prompt-choices": "^4.0.5"
       },
       "dependencies": {
         "debug": {
@@ -1048,7 +1103,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            "ms": "2.0.0"
           }
         },
         "kind-of": {
@@ -1063,9 +1118,9 @@
       "resolved": "https://registry.npmjs.org/radio-symbol/-/radio-symbol-2.0.0.tgz",
       "integrity": "sha1-eqm/xQSFY21S3XbWqOYxspB5muE=",
       "requires": {
-        "ansi-gray": "0.1.1",
-        "ansi-green": "0.1.1",
-        "is-windows": "1.0.1"
+        "ansi-gray": "^0.1.1",
+        "ansi-green": "^0.1.1",
+        "is-windows": "^1.0.1"
       }
     },
     "readline-ui": {
@@ -1073,10 +1128,10 @@
       "resolved": "https://registry.npmjs.org/readline-ui/-/readline-ui-2.2.3.tgz",
       "integrity": "sha512-ix7jz0PxqQqcIuq3yQTHv1TOhlD2IHO74aNO+lSuXsRYm1d+pdyup1yF3zKyLK1wWZrVNGjkzw5tUegO2IDy+A==",
       "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "readline-utils": "2.2.3",
-        "string-width": "2.1.1"
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.8",
+        "readline-utils": "^2.2.1",
+        "string-width": "^2.0.0"
       }
     },
     "readline-utils": {
@@ -1084,15 +1139,15 @@
       "resolved": "https://registry.npmjs.org/readline-utils/-/readline-utils-2.2.3.tgz",
       "integrity": "sha1-b4R9a48ZFcORtYHDZ81HhzhiNRo=",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "extend-shallow": "2.0.1",
-        "is-buffer": "1.1.6",
-        "is-number": "3.0.0",
-        "is-windows": "1.0.1",
-        "koalas": "1.0.2",
+        "arr-flatten": "^1.1.0",
+        "extend-shallow": "^2.0.1",
+        "is-buffer": "^1.1.5",
+        "is-number": "^3.0.0",
+        "is-windows": "^1.0.1",
+        "koalas": "^1.0.2",
         "mute-stream": "0.0.7",
-        "strip-color": "0.1.0",
-        "window-size": "1.1.0"
+        "strip-color": "^0.1.0",
+        "window-size": "^1.1.0"
       }
     },
     "set-getter": {
@@ -1100,7 +1155,7 @@
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "set-value": {
@@ -1108,10 +1163,10 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.0.2"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       }
     },
     "shallow-clone": {
@@ -1119,9 +1174,9 @@
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
       "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "5.1.0",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^5.0.0",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -1132,23 +1187,26 @@
       }
     },
     "source-map": {
-      "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
       "optional": true,
       "requires": {
-        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+        "amdefine": ">=0.0.4"
       }
     },
     "source-map-support": {
-      "version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
       "integrity": "sha1-byFQVT5jdTddDMsxgFAreMGLpDA=",
       "dev": true,
       "requires": {
-        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
+        "source-map": "^0.5.6"
       },
       "dependencies": {
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -1159,7 +1217,7 @@
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz",
       "integrity": "sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==",
       "requires": {
-        "extend-shallow": "2.0.1"
+        "extend-shallow": "^2.0.1"
       }
     },
     "static-extend": {
@@ -1167,8 +1225,8 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -1176,7 +1234,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "is-descriptor": {
@@ -1184,9 +1242,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           }
         },
         "kind-of": {
@@ -1201,8 +1259,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "strip-ansi": {
@@ -1210,11 +1268,12 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
-      "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
@@ -1224,7 +1283,8 @@
       "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s="
     },
     "strip-json-comments": {
-      "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
@@ -1234,11 +1294,12 @@
       "integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc="
     },
     "supports-color": {
-      "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+        "has-flag": "^1.0.0"
       }
     },
     "terminal-paginator": {
@@ -1246,9 +1307,9 @@
       "resolved": "https://registry.npmjs.org/terminal-paginator/-/terminal-paginator-2.0.2.tgz",
       "integrity": "sha512-IZMT5ECF9p4s+sNCV8uvZSW9E1+9zy9Ji9xz2oee8Jfo7hUFpauyjxkhfRcIH6Lu3Wdepv5D1kVRc8Hx74/LfQ==",
       "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-        "extend-shallow": "2.0.1",
-        "log-utils": "0.2.1"
+        "debug": "^2.6.6",
+        "extend-shallow": "^2.0.1",
+        "log-utils": "^0.2.1"
       }
     },
     "time-stamp": {
@@ -1261,7 +1322,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "toggle-array": {
@@ -1269,69 +1330,77 @@
       "resolved": "https://registry.npmjs.org/toggle-array/-/toggle-array-1.0.1.tgz",
       "integrity": "sha1-y/WEB5K9UJfzMReugkyTKv/ofVg=",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "ts-node": {
-      "version": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
       "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
       "dev": true,
       "requires": {
-        "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-        "chalk": "2.3.0",
-        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-        "make-error": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-        "source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
-        "tsconfig": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
-        "v8flags": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.0.tgz",
-        "yn": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz"
+        "arrify": "^1.0.0",
+        "chalk": "^2.0.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.0",
+        "tsconfig": "^6.0.0",
+        "v8flags": "^3.0.0",
+        "yn": "^2.0.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
     },
     "tsconfig": {
-      "version": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
       "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
       "dev": true,
       "requires": {
-        "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-        "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
       }
     },
     "type-check": {
-      "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
-      "version": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
     "typescript": {
-      "version": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
       "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ="
     },
     "user-home": {
-      "version": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
       "dev": true
     },
     "v8flags": {
-      "version": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.0.tgz",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.0.tgz",
       "integrity": "sha1-S+lgRIjgxBI2Rd73BbGEjRa44B8=",
       "dev": true,
       "requires": {
-        "user-home": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        "user-home": "^1.1.1"
       }
     },
     "warning-symbol": {
@@ -1344,21 +1413,24 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-1.1.0.tgz",
       "integrity": "sha1-O0AtMkTzVWHbLJdhrZ0eUoawei0=",
       "requires": {
-        "define-property": "1.0.0",
-        "is-number": "3.0.0"
+        "define-property": "^1.0.0",
+        "is-number": "^3.0.0"
       }
     },
     "wordwrap": {
-      "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "yn": {
-      "version": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldmind/tspath",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "TypeScript Path Igniter resolves @paths specified in tsconfig",
   "scripts": {
     "build": "tsc",

--- a/src/parent-file-finder.ts
+++ b/src/parent-file-finder.ts
@@ -38,18 +38,17 @@
 
  =---------------------------------------------------------------= */
 
-import * as fs       from "fs";
-import * as path     from "path";
-import { Utils }     from "./utils";
+import * as fs from "fs";
+import * as path from "path";
+import { Utils } from "./utils";
 import { TS_CONFIG } from "./type-definitions";
 
 export class FileFindResult {
-	constructor(
-		public fileFound: boolean = false,
-		public path: string = "",
-		public result: string = ""
-	)
-	{}
+    constructor(
+        public fileFound: boolean = false,
+        public path: string = "",
+        public result: string = ""
+    ) { }
 }
 
 export class ParentFileFinder {
@@ -60,31 +59,31 @@ export class ParentFileFinder {
 	 * @param filename
 	 * @returns {FileFindResult}
 	 */
-	public static findFile(startPath: string, filename: string): FileFindResult {
-		let result = new FileFindResult();
-		let sep = path.sep;
-		var parts = startPath.split(sep);
+    public static findFile(startPath: string, filename: string): FileFindResult {
+        let result = new FileFindResult();
+        let sep = path.sep;
+        var parts = startPath.split(sep);
 
-		var tmpStr = sep;
+        var tmpStr = sep;
 
-		for (var i = 0; i < parts.length; i++) {
-			tmpStr = path.resolve(tmpStr, parts[i]);
-			tmpStr = Utils.ensureTrailingPathDelimiter(tmpStr);
-			parts[i] = tmpStr;
-		}
+        for (var i = 0; i < parts.length; i++) {
+            tmpStr = path.resolve(tmpStr, parts[i]) as "/" | "\\";
+            tmpStr = Utils.ensureTrailingPathDelimiter(tmpStr) as "/" | "\\";
+            parts[i] = tmpStr;
+        }
 
-		for (var i = parts.length-1; i > 0; i--) {
-			tmpStr = parts[i];
-			filename = path.resolve(tmpStr, TS_CONFIG);
+        for (var i = parts.length - 1; i > 0; i--) {
+            tmpStr = parts[i] as "/" | "\\";
+            filename = path.resolve(tmpStr, TS_CONFIG);
 
-			if (fs.existsSync(filename)) {
-				result.fileFound = true;
-				result.path = tmpStr;
-				result.result = filename;
-				break;
-			}
-		}
+            if (fs.existsSync(filename)) {
+                result.fileFound = true;
+                result.path = tmpStr;
+                result.result = filename;
+                break;
+            }
+        }
 
-		return result;
-	}
+        return result;
+    }
 }

--- a/src/parser-engine.ts
+++ b/src/parser-engine.ts
@@ -122,8 +122,7 @@ export class ParserEngine {
 			log(chalk.yellow.bold("Parsing project at: ") + '"' +  this.projectPath + '"');
 		}
 
-		this.appRoot = path.resolve(this.projectPath, this.projectOptions.baseUrl);
-		this.appRoot = path.resolve(this.appRoot, this.projectOptions.outDir);
+    this.appRoot = path.resolve(this.projectPath, this.projectOptions.outDir);
 
 		let fileList = new Array<string>();
 

--- a/src/parser-engine.ts
+++ b/src/parser-engine.ts
@@ -22,123 +22,124 @@
 
 =----------------------------------------------------------------= */
 
-let fs             = require("fs");
-let path           = require('path');
-let esprima        = require("esprima");
-let escodegen      = require("escodegen");
-let chalk          = require("chalk");
+let fs = require("fs");
+let path = require('path');
+let esprima = require("esprima");
+let escodegen = require("escodegen");
+let chalk = require("chalk");
 
-import { Utils }                from "./utils";
-import { JsonCommentStripper }  from "./json-comment-stripper";
-import { ProjectOptions }       from "./project-options";
-import { TS_CONFIG }            from "./type-definitions";
-import { FILE_ENCODING }        from "./type-definitions";
+import { Utils } from "./utils";
+import { JsonCommentStripper } from "./json-comment-stripper";
+import { ProjectOptions } from "./project-options";
+import { TS_CONFIG } from "./type-definitions";
+import { FILE_ENCODING } from "./type-definitions";
+import { TSPath } from './tspath';
 
-const log          = console.log;
+const log = console.log;
 
 export class ParserEngine {
-	public projectPath: string;
+    public projectPath: string;
 
-	nrFilesProcessed : number = 0;
-	nrPathsProcessed : number = 0;
-	appRoot          : string;
-	projectOptions   : ProjectOptions;
-	tsConfig         : any;
+    nrFilesProcessed: number = 0;
+    nrPathsProcessed: number = 0;
+    appRoot: string;
+    projectOptions: ProjectOptions;
+    tsConfig: any;
 
-	constructor() {}
+    constructor() { }
 
-	public exit(code: number = 5) {
-		console.log("Terminating...");
-		process.exit(code);
-	}
+    public exit(code: number = 5) {
+        console.log("Terminating...");
+        process.exit(code);
+    }
 
-	public setProjectPath(projectPath: string): boolean {
+    public setProjectPath(projectPath: string): boolean {
 
 		/*
 		this.projectPath = process.cwd();
 		console.log("CURRENT:", this.projectPath);
 		*/
 
-		if (!Utils.isEmpty(projectPath) && !this.validateProjectPath(projectPath)) {
-			log(chalk.red.bold("Project Path \"" + chalk.underline(projectPath) + "\" is invalid!"));
-			return false;
-		}
+        if (!Utils.isEmpty(projectPath) && !this.validateProjectPath(projectPath)) {
+            log(chalk.red.bold("Project Path \"" + chalk.underline(projectPath) + "\" is invalid!"));
+            return false;
+        }
 
-		this.projectPath = projectPath;
+        this.projectPath = projectPath;
 
-		return true;
-	}
+        return true;
+    }
 
-	private validateProjectPath(projectPath: string): boolean {
-		var result = true;
+    private validateProjectPath(projectPath: string): boolean {
+        var result = true;
 
-		let configFile = Utils.ensureTrailingPathDelimiter(projectPath);
-		configFile += TS_CONFIG;
+        let configFile = Utils.ensureTrailingPathDelimiter(projectPath);
+        configFile += TS_CONFIG;
 
-		if (!fs.existsSync(projectPath)) {
-			result = false;
-		}
+        if (!fs.existsSync(projectPath)) {
+            result = false;
+        }
 
-		if (!fs.existsSync(configFile)) {
-			log("TypeScript Compiler Configuration file " + chalk.underline.bold(TS_CONFIG) + " is missing!");
-		}
+        if (!fs.existsSync(configFile)) {
+            log("TypeScript Compiler Configuration file " + chalk.underline.bold(TS_CONFIG) + " is missing!");
+        }
 
-		return result;
-	}
+        return result;
+    }
 
 	/**
 	 * Attempts to read the name property form package.json
 	 * @returns {string}
 	 */
-	private readProjectName(): string {
-		var projectName: string = null;
-		var filename = path.resolve(this.projectPath, "package.json");
+    private readProjectName(): string {
+        var projectName: string = null;
+        var filename = path.resolve(this.projectPath, "package.json");
 
-		if (fs.existsSync(filename)) {
-			var json = require(filename);
-			projectName = json.name;
-		}
+        if (fs.existsSync(filename)) {
+            var json = require(filename);
+            projectName = json.name;
+        }
 
-		return projectName;
-	}
+        return projectName;
+    }
 
 
-	public execute() {
-		const  PROCESS_TIME = "Operation finished in";
-		console.time(PROCESS_TIME);
+    public execute() {
+        const PROCESS_TIME = "Operation finished in";
+        console.time(PROCESS_TIME);
 
-		if (!this.validateProjectPath(this.projectPath)) {
-			log(chalk.bold.red("Invalid project path"));
-			this.exit(10);
-		}
+        if (!this.validateProjectPath(this.projectPath)) {
+            log(chalk.bold.red("Invalid project path"));
+            this.exit(10);
+        }
 
-		this.projectOptions = this.readConfig();
+        this.projectOptions = this.readConfig();
 
-		let projectName = this.readProjectName();
+        let projectName = this.readProjectName();
 
-		if (!Utils.isEmpty(projectName)) {
-			log(chalk.yellow("Parsing project: ") + chalk.bold(projectName) + " " + chalk.underline(this.projectPath));
-		} else {
-			log(chalk.yellow.bold("Parsing project at: ") + '"' +  this.projectPath + '"');
-		}
+        if (!Utils.isEmpty(projectName)) {
+            log(chalk.yellow("Parsing project: ") + chalk.bold(projectName) + " " + chalk.underline(this.projectPath));
+        } else {
+            log(chalk.yellow.bold("Parsing project at: ") + '"' + this.projectPath + '"');
+        }
 
-    this.appRoot = path.resolve(this.projectPath, this.projectOptions.outDir);
+        this.appRoot = path.resolve(this.projectPath, this.projectOptions.outDir);
 
-		let fileList = new Array<string>();
+        let fileList = new Array<string>();
 
-		this.walkSync(this.appRoot, fileList, ".js");
+        this.walkSync(this.appRoot, fileList, ".js");
 
-		for (var i = 0; i < fileList.length; i++) {
-			let filename = fileList[i];
-			this.processFile(filename);
-		}
+        for (var i = 0; i < fileList.length; i++) {
+            let filename = fileList[i];
+            this.processFile(filename);
+        }
 
-		log(chalk.bold("Total files processed:"), this.nrFilesProcessed);
-		log(chalk.bold("Total paths processed:"), this.nrPathsProcessed);
+        log(chalk.bold("Total files processed:"), this.nrFilesProcessed);
+        log(chalk.bold("Total paths processed:"), this.nrPathsProcessed);
 
-		console.timeEnd(PROCESS_TIME);
-		log(chalk.bold.green("Project is prepared, now run it normally!"));
-	}
+        console.timeEnd(PROCESS_TIME);
+        log(chalk.bold.green("Project is prepared, now run it normally!"));
+    }
 
 	/**
 	 *
@@ -146,38 +147,38 @@ export class ParserEngine {
 	 * @param jsRequire - require in javascript source "require("jsRequire")
 	 * @returns {string}
 	 */
-	getRelativePathForRequiredFile(sourceFilename: string, jsRequire: string) {
-		let options = this.projectOptions;
+    getRelativePathForRequiredFile(sourceFilename: string, jsRequire: string) {
+        let options = this.projectOptions;
 
-		for (var alias in options.pathMappings) {
-			var mapping = options.pathMappings[alias];
+        for (var alias in options.pathMappings) {
+            var mapping = options.pathMappings[alias];
 
-			//TODO: Handle * properly
-			alias = Utils.stripWildcard(alias);
-			mapping = Utils.stripWildcard(mapping);
+            //TODO: Handle * properly
+            alias = Utils.stripWildcard(alias);
+            mapping = Utils.stripWildcard(mapping);
 
-			if (jsRequire.substring(0, alias.length) == alias) {
-				var result = jsRequire.replace(alias, mapping);
-				Utils.replaceDoubleSlashes(result);
+            if (jsRequire.substring(0, alias.length) == alias) {
+                var result = jsRequire.replace(alias, mapping);
+                Utils.replaceDoubleSlashes(result);
 
-				var absoluteJsRequire = path.join(this.appRoot, result);
-				var sourceDir = path.dirname(sourceFilename);
+                var absoluteJsRequire = path.join(this.appRoot, result);
+                var sourceDir = path.dirname(sourceFilename);
 
-				let relativePath = path.relative(sourceDir, absoluteJsRequire);
+                let relativePath = path.relative(sourceDir, absoluteJsRequire);
 
 				/* If the path does not start with .. it´ not a sub directory
 				 * as in ../ or ..\ so assume it´ the same dir...
 				 */
-				if (relativePath[0] != ".") {
-					relativePath = "./" + relativePath;
-				}
+                if (relativePath[0] != ".") {
+                    relativePath = "./" + relativePath;
+                }
 
-				return relativePath;
-			}
-		}
+                return relativePath;
+            }
+        }
 
-		return jsRequire;
-	}
+        return jsRequire;
+    }
 
 	/**
 	 * Processes the filename specified in require("filename")
@@ -185,104 +186,106 @@ export class ParserEngine {
 	 * @param sourceFilename
 	 * @returns {any}
 	 */
-	processJsRequire(node: any, sourceFilename: string): any {
-		let resultNode = node;
-		let requireInJsFile = Utils.safeGetAstNodeValue(node);
+    processJsRequire(node: any, sourceFilename: string): any {
+        let resultNode = node;
+        let requireInJsFile = Utils.safeGetAstNodeValue(node);
 
 		/* Only proceed if the "require" contains a full file path, not
 		 * single references like "inversify"
 		 */
-		if (!Utils.isEmpty(requireInJsFile) && Utils.fileHavePath(requireInJsFile)) {
-			let relativePath = this.getRelativePathForRequiredFile(sourceFilename, requireInJsFile);
-			resultNode = {type: "Literal", value: relativePath, raw: relativePath};
+        if (!Utils.isEmpty(requireInJsFile) && Utils.fileHavePath(requireInJsFile)) {
+            let relativePath = this.getRelativePathForRequiredFile(sourceFilename, requireInJsFile);
+            resultNode = { type: "Literal", value: relativePath, raw: relativePath };
 
-			this.nrPathsProcessed++;
-		}
+            this.nrPathsProcessed++;
+        }
 
-		return resultNode;
-	}
+        return resultNode;
+    }
 
 	/**
 	 * Extracts all the requires from a single file and processes the paths
 	 * @param filename
 	 */
-	processFile(filename: string) {
-		this.nrFilesProcessed++;
+    processFile(filename: string) {
+        this.nrFilesProcessed++;
 
-		let scope = this;
-		let inputSourceCode = fs.readFileSync(filename, FILE_ENCODING);
-		var ast = null;
+        let scope = this;
+        let inputSourceCode = fs.readFileSync(filename, FILE_ENCODING);
+        var ast = null;
 
-		try {
-			ast = esprima.parse(inputSourceCode); //, { raw: true, tokens: true, range: true, comment: true });
-		}
-		catch(error) {
-			console.log("Unable to parse file:", filename);
-			console.log("Error:", error);
-			this.exit();
-		}
+        try {
+            ast = esprima.parse(inputSourceCode); //, { raw: true, tokens: true, range: true, comment: true });
+        }
+        catch (error) {
+            console.log("Unable to parse file:", filename);
+            console.log("Error:", error);
+            this.exit();
+        }
 
-		this.traverseSynTree(ast, this, function(node) {
-			if (node != undefined && node.type == "CallExpression" && node.callee.name == "require") {
-				node.arguments[0] = scope.processJsRequire(node.arguments[0], filename);
-			}
-		});
+        this.traverseSynTree(ast, this, function (node) {
+            if (node != undefined && node.type == "CallExpression" && node.callee.name == "require") {
+                node.arguments[0] = scope.processJsRequire(node.arguments[0], filename);
+            }
+        });
 
-		let option = { comment: true, format: { compact: true,  quotes: '"' }};
-		let finalSource = escodegen.generate(ast, option);
+        let option = { comment: true };
+        if (TSPath.parseCommandLineParam("-c"))
+            option['format'] = { compact: true, quotes: '"' };
+        let finalSource = escodegen.generate(ast, option);
 
-		try {
-			this.saveFileContents(filename, finalSource);
-		}
-		catch(error) {
-			log(chalk.bold.red("Unable to write file:"), filename);
-			this.exit();
-		}
-	}
+        try {
+            this.saveFileContents(filename, finalSource);
+        }
+        catch (error) {
+            log(chalk.bold.red("Unable to write file:"), filename);
+            this.exit();
+        }
+    }
 
 	/**
 	 * Saves file contents to disk
 	 * @param filename
 	 * @param fileContents
 	 */
-	saveFileContents(filename: string, fileContents: string) {
-		var error: any = false;
-		fs.writeFileSync(filename, fileContents, FILE_ENCODING, error);
+    saveFileContents(filename: string, fileContents: string) {
+        var error: any = false;
+        fs.writeFileSync(filename, fileContents, FILE_ENCODING, error);
 
-		if (error) {
-			throw Error("Could not save file: " +  filename);
-		}
-	}
+        if (error) {
+            throw Error("Could not save file: " + filename);
+        }
+    }
 
 	/**
 	 * Read and parse the TypeScript configuration file
 	 * @param configFilename
 	 */
-	readConfig(configFilename: string = TS_CONFIG): ProjectOptions {
-		let fileName = path.resolve(this.projectPath, configFilename);
-		let fileData = fs.readFileSync(path.resolve(this.projectPath, fileName), FILE_ENCODING);
+    readConfig(configFilename: string = TS_CONFIG): ProjectOptions {
+        let fileName = path.resolve(this.projectPath, configFilename);
+        let fileData = fs.readFileSync(path.resolve(this.projectPath, fileName), FILE_ENCODING);
 
-		let jsonCS = new JsonCommentStripper();
-		fileData = jsonCS.stripComments(fileData);
+        let jsonCS = new JsonCommentStripper();
+        fileData = jsonCS.stripComments(fileData);
 
-		this.tsConfig = JSON.parse(fileData);
+        this.tsConfig = JSON.parse(fileData);
 
-		let compilerOpt = this.tsConfig.compilerOptions;
+        let compilerOpt = this.tsConfig.compilerOptions;
 
-		let reqFields = [];
-		reqFields["baseUrl"] = compilerOpt.baseUrl;
-		reqFields["outDir"] = compilerOpt.outDir;
+        let reqFields = [];
+        reqFields["baseUrl"] = compilerOpt.baseUrl;
+        reqFields["outDir"] = compilerOpt.outDir;
 
-		for (var key in reqFields) {
-			var field = reqFields[key];
-			if (Utils.isEmpty(field)) {
-				log(chalk.red.bold("Missing required field:") + ' "' + chalk.bold.underline(key) + '"');
-				this.exit(22);
-			}
-		}
+        for (var key in reqFields) {
+            var field = reqFields[key];
+            if (Utils.isEmpty(field)) {
+                log(chalk.red.bold("Missing required field:") + ' "' + chalk.bold.underline(key) + '"');
+                this.exit(22);
+            }
+        }
 
-		return new ProjectOptions(compilerOpt);
-	}
+        return new ProjectOptions(compilerOpt);
+    }
 
 	/**
 	 *
@@ -290,24 +293,24 @@ export class ParserEngine {
 	 * @param scope
 	 * @param func
 	 */
-	traverseSynTree(ast, scope, func) {
-		func(ast);
-		for (var key in ast) {
-			if (ast.hasOwnProperty(key)) {
-				var child = ast[key];
+    traverseSynTree(ast, scope, func) {
+        func(ast);
+        for (var key in ast) {
+            if (ast.hasOwnProperty(key)) {
+                var child = ast[key];
 
-				if (typeof child === 'object' && child !== null) {
-					if (Array.isArray(child)) {
-						child.forEach(function(ast) { //5
-							scope.traverseSynTree(ast, scope, func);
-						});
-					} else {
-						scope.traverseSynTree(child, scope, func);
-					}
-				}
-			}
-		}
-	}
+                if (typeof child === 'object' && child !== null) {
+                    if (Array.isArray(child)) {
+                        child.forEach(function (ast) { //5
+                            scope.traverseSynTree(ast, scope, func);
+                        });
+                    } else {
+                        scope.traverseSynTree(child, scope, func);
+                    }
+                }
+            }
+        }
+    }
 
 	/**
 	 * Recursively walking a directory structure and collect files
@@ -316,31 +319,31 @@ export class ParserEngine {
 	 * @param fileExtension
 	 * @returns {Array<string>}
 	 */
-	public walkSync(dir: string, filelist: Array<string>, fileExtension?: string) {
-		var scope = this;
-		var	files = fs.readdirSync(dir);
-		filelist = filelist || [];
+    public walkSync(dir: string, filelist: Array<string>, fileExtension?: string) {
+        var scope = this;
+        var files = fs.readdirSync(dir);
+        filelist = filelist || [];
 
-		fileExtension = fileExtension === undefined ? "" : fileExtension;
+        fileExtension = fileExtension === undefined ? "" : fileExtension;
 
-		for (var i = 0; i < files.length; i++) {
-			var file = files[i];
+        for (var i = 0; i < files.length; i++) {
+            var file = files[i];
 
-			if (fs.statSync(path.join(dir, file)).isDirectory()) {
-				filelist = this.walkSync(path.join(dir, file), filelist, fileExtension);
-			}
-			else {
-				var tmpExt = path.extname(file);
+            if (fs.statSync(path.join(dir, file)).isDirectory()) {
+                filelist = this.walkSync(path.join(dir, file), filelist, fileExtension);
+            }
+            else {
+                var tmpExt = path.extname(file);
 
-				if ((fileExtension.length > 0 && tmpExt == fileExtension)
-					|| (fileExtension.length < 1)
-					|| (fileExtension == "*.*")) {
-					let fullFilename = path.join(dir, file);
-					filelist.push(fullFilename);
-				}
-			}
-		}
+                if ((fileExtension.length > 0 && tmpExt == fileExtension)
+                    || (fileExtension.length < 1)
+                    || (fileExtension == "*.*")) {
+                    let fullFilename = path.join(dir, file);
+                    filelist.push(fullFilename);
+                }
+            }
+        }
 
-		return filelist;
-	}
+        return filelist;
+    }
 }

--- a/src/tspath.ts
+++ b/src/tspath.ts
@@ -24,65 +24,68 @@
 
  =----------------------------------------------------------------= */
 
-let fs         = require("fs");
-let path       = require("path");
-let chalk      = require("chalk");
-const log      = console.log;
+let fs = require("fs");
+let path = require("path");
+let chalk = require("chalk");
+const log = console.log;
 
 let Confirm = require('prompt-confirm');
 
-import { ParserEngine }     from "./parser-engine";
+import { ParserEngine } from "./parser-engine";
 import { ParentFileFinder } from "./parent-file-finder";
-import { TS_CONFIG }        from "./type-definitions";
+import { TS_CONFIG } from "./type-definitions";
 
 const pkg = require('../package.json');
 
 export class TSPath {
-	private engine = new ParserEngine();
+    private engine = new ParserEngine();
 
-	constructor() {
-		log(chalk.yellow("TSPath " + pkg.version));
-		let args = process.argv.slice(2);
-		let param = args[0];
+    constructor() {
+        log(chalk.yellow("TSPath " + pkg.version));
 
-		let projectPath = process.cwd();
+        let param = TSPath.parseCommandLineParam("-f");
 
-		let findResult = ParentFileFinder.findFile(projectPath, TS_CONFIG);
+        let projectPath = process.cwd();
 
-		var scope = this;
+        let findResult = ParentFileFinder.findFile(projectPath, TS_CONFIG);
 
-		if (param == "-f" && findResult.fileFound) {
-			scope.processPath(findResult.path);
+        var scope = this;
 
-		} else if (findResult.fileFound) {
-			let confirm = new Confirm("Process project at: <"  + findResult.path +  "> ?")
-				.ask(function(answer) {
-					if (answer) {
-						scope.processPath(findResult.path);
-					}
-				});
+        if (param && findResult.fileFound) {
+            scope.processPath(findResult.path);
 
-		} else {
-			log(chalk.bold("No project root found!"));
-		}
-	}
+        } else if (findResult.fileFound) {
+            let confirm = new Confirm("Process project at: <" + findResult.path + "> ?")
+                .ask(function (answer) {
+                    if (answer) {
+                        scope.processPath(findResult.path);
+                    }
+                });
 
-	private processPath(projectPath: string) {
-		if (this.engine.setProjectPath(projectPath)) {
-			this.engine.execute();
-		}
-	}
+        } else {
+            log(chalk.bold("No project root found!"));
+        }
+    }
 
-	public parseCommandLineParam(): string {
-		let args = process.argv.slice(2);
-		var param: string = null;
+    private processPath(projectPath: string) {
+        if (this.engine.setProjectPath(projectPath)) {
+            this.engine.execute();
+        }
+    }
 
-		if (args.length != 1) {
-			param = args[0];
-		}
+    public static parseCommandLineParam(id: string): string {
+        let args = process.argv.slice(2);
+        var param: string = null;
+        const argsLen = args.length;
+        let counter = 0;
+        while (param === null && counter < argsLen) {
+            if (args[counter] === id)
+                param = args[counter];
+            counter++;
+        };
 
-		return param;
-	}
+        return param;
+    }
 }
 
 let tspath = new TSPath();


### PR DESCRIPTION
I was experiencing some weird behaviour when running with node 8.9.3 (in Electron).

After some testing, I've found out that disabling the `compat` option when calling `escodegen.generate` solves the issue. This might also be related to the shaky behaviour with node 9.x.

To solve this, I've made the `compat` formatting optional, now it is applied if `-c` is passed via CLI.

To better handle params, I've also rewritten `parseCommandLineParam` as a `static public` method of TSPath, as it was not used before. Now `parseCommandLineParam` expects 1 argument, the name of the parameter (e.g. `-f`), and it returns the parameter or `null` (e.g. `-f | null`).

This new method is used both in the parser engine to detect the `-c` option, and in TsPath to detect the `-f` option.

With this pull request I've also committed some changes to `parent-file-finder.ts`. There I've added `as "/" | "\\"` to prevent `tsc` from throwing an error when running `build`.

Finally, I've updated the `Options` table in the readme file.

PS @duffman if you need any help maintaining this project, I'm happy to help.