### PR TITLE
only include js files

### DIFF
--- a/dist/src/json-comment-stripper.d.ts
+++ b/dist/src/json-comment-stripper.d.ts
@@ -3,10 +3,10 @@ export declare class JsonCommentStripper {
     private prevtState;
     constructor();
     stripComments(data: string): string;
-    private isQuote(char);
-    private setState(state);
-    private inState(state);
-    private setPrevState();
-    private inComment();
+    private isQuote;
+    private setState;
+    private inState;
+    private setPrevState;
+    private inComment;
     parse(data: string): string;
 }

--- a/dist/src/parent-file-finder.js
+++ b/dist/src/parent-file-finder.js
@@ -23,14 +23,6 @@
 
  =---------------------------------------------------------------=
 
- Json Comment Stripper
-
- Simple Parser used to strip block and line comments form a
- JSON formatted string.
-
- Worth knowing: The parser treat " and ' the same, so it´s
- possible to start a string with " and end it with '
-
  This file is part of the TypeScript Path Igniter Project:
  https://github.com/duffman/ts-path-igniter
 
@@ -62,14 +54,14 @@ class ParentFileFinder {
     static findFile(startPath, filename) {
         let result = new FileFindResult();
         let sep = path.sep;
-        var parts = startPath.split(sep);
-        var tmpStr = sep;
-        for (var i = 0; i < parts.length; i++) {
+        let parts = startPath.split(sep);
+        let tmpStr = sep;
+        for (let i = 0; i < parts.length; i++) {
             tmpStr = path.resolve(tmpStr, parts[i]);
             tmpStr = utils_1.Utils.ensureTrailingPathDelimiter(tmpStr);
             parts[i] = tmpStr;
         }
-        for (var i = parts.length - 1; i > 0; i--) {
+        for (let i = parts.length - 1; i > 0; i--) {
             tmpStr = parts[i];
             filename = path.resolve(tmpStr, type_definitions_1.TS_CONFIG);
             if (fs.existsSync(filename)) {

--- a/dist/src/parser-engine.d.ts
+++ b/dist/src/parser-engine.d.ts
@@ -4,17 +4,28 @@ export declare class ParserEngine {
     nrFilesProcessed: number;
     nrPathsProcessed: number;
     appRoot: string;
+    distRoot: string;
+    compactMode: boolean;
     projectOptions: ProjectOptions;
     tsConfig: any;
+    fileFilter: Array<string>;
     constructor();
     exit(code?: number): void;
     setProjectPath(projectPath: string): boolean;
-    private validateProjectPath(projectPath);
+    /**
+     * Set the accepted file extensions, ensure leading . (dot)
+     * @param {Array<string>} filter
+     */
+    setFileFilter(filter: Array<string>): void;
+    private validateProjectPath;
     /**
      * Attempts to read the name property form package.json
      * @returns {string}
      */
-    private readProjectName();
+    private readProjectName;
+    /**
+     * Parse project and resolve paths
+     */
     execute(): void;
     /**
      *
@@ -22,7 +33,7 @@ export declare class ParserEngine {
      * @param jsRequire - require in javascript source "require("jsRequire")
      * @returns {string}
      */
-    getRelativePathForRequiredFile(sourceFilename: string, jsRequire: string): any;
+    getRelativePathForRequiredFile(sourceFilename: string, jsRequire: string): string;
     /**
      * Processes the filename specified in require("filename")
      * @param node
@@ -53,6 +64,12 @@ export declare class ParserEngine {
      * @param func
      */
     traverseSynTree(ast: any, scope: any, func: any): void;
+    /**
+     * Match a given file extension with the configured extensions
+     * @param {string} fileExtension - ".xxx" or "xxx
+     * @returns {boolean}
+     */
+    private matchExtension;
     /**
      * Recursively walking a directory structure and collect files
      * @param dir

--- a/dist/src/parser-engine.js
+++ b/dist/src/parser-engine.js
@@ -290,10 +290,10 @@ class ParserEngine {
                 filelist = this.walkSync(path.join(dir, file), filelist, fileExtension);
             }
             else {
-                let tmpExt = path.extname(file);
-                if ((fileExtension.length > 0 && scope.matchExtension(fileExtension))
-                    || (fileExtension.length < 1)
-                    || (fileExtension == "*.*")) {
+                let fileExt = path.extname(file);
+                if ((fileExt.length > 0 && scope.matchExtension(fileExt))
+                    || (fileExt.length < 1)
+                    || (fileExt == "*.*")) {
                     let fullFilename = path.join(dir, file);
                     filelist.push(fullFilename);
                 }

--- a/dist/src/tspath.d.ts
+++ b/dist/src/tspath.d.ts
@@ -1,6 +1,6 @@
+#! /usr/bin/env node
 export declare class TSPath {
     private engine;
     constructor();
-    private processPath(projectPath);
-    parseCommandLineParam(): string;
+    private processPath;
 }

--- a/dist/src/tspath.js
+++ b/dist/src/tspath.js
@@ -1,25 +1,41 @@
 #! /usr/bin/env node
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+const pkg = require('../package.json');
 let fs = require("fs");
 let path = require("path");
 let chalk = require("chalk");
-const log = console.log;
+let log = console.log;
 let Confirm = require('prompt-confirm');
+let yargs = require("yargs").argv;
 const parser_engine_1 = require("./parser-engine");
 const parent_file_finder_1 = require("./parent-file-finder");
 const type_definitions_1 = require("./type-definitions");
-const pkg = require('../package.json');
 class TSPath {
     constructor() {
         this.engine = new parser_engine_1.ParserEngine();
         log(chalk.yellow("TSPath " + pkg.version));
         let args = process.argv.slice(2);
         let param = args[0];
+        let filter = ["js"];
+        let force = (yargs.force || yargs.f);
         let projectPath = process.cwd();
+        let compactOutput = yargs.preserve ? false : true;
         let findResult = parent_file_finder_1.ParentFileFinder.findFile(projectPath, type_definitions_1.TS_CONFIG);
-        var scope = this;
-        if (param == "-f" && findResult.fileFound) {
+        let scope = this;
+        if (yargs.ext || yargs.filter) {
+            let argFilter = yargs.ext ? yargs.ext : yargs.filter;
+            filter = argFilter.split(",").map((ext) => {
+                return ext.replace(/\s/g, "");
+            });
+        }
+        if (filter.length === 0) {
+            log(chalk.bold.red("File filter missing!"));
+            process.exit(23);
+        }
+        this.engine.compactMode = compactOutput;
+        this.engine.setFileFilter(filter);
+        if (force && findResult.fileFound) {
             scope.processPath(findResult.path);
         }
         else if (findResult.fileFound) {
@@ -38,14 +54,6 @@ class TSPath {
         if (this.engine.setProjectPath(projectPath)) {
             this.engine.execute();
         }
-    }
-    parseCommandLineParam() {
-        let args = process.argv.slice(2);
-        var param = null;
-        if (args.length != 1) {
-            param = args[0];
-        }
-        return param;
     }
 }
 exports.TSPath = TSPath;

--- a/dist/src/tspath.js
+++ b/dist/src/tspath.js
@@ -17,7 +17,7 @@ class TSPath {
         log(chalk.yellow("TSPath " + pkg.version));
         let args = process.argv.slice(2);
         let param = args[0];
-        let filter = ["js"];
+        let filter = ["js", "jsx"];
         let force = (yargs.force || yargs.f);
         let projectPath = process.cwd();
         let compactOutput = yargs.preserve ? false : true;

--- a/src/parser-engine.ts
+++ b/src/parser-engine.ts
@@ -354,11 +354,11 @@ export class ParserEngine {
 				filelist = this.walkSync(path.join(dir, file), filelist, fileExtension);
 			}
 			else {
-				let tmpExt = path.extname(file);
+				let fileExt = path.extname(file);
 
-				if ((fileExtension.length > 0 && scope.matchExtension(fileExtension))
-					|| (fileExtension.length < 1)
-					|| (fileExtension == "*.*")) {
+				if ((fileExt.length > 0 && scope.matchExtension(fileExt))
+					|| (fileExt.length < 1)
+					|| (fileExt == "*.*")) {
 					let fullFilename = path.join(dir, file);
 					filelist.push(fullFilename);
 				}

--- a/src/tspath.ts
+++ b/src/tspath.ts
@@ -44,7 +44,7 @@ export class TSPath {
 		log(chalk.yellow("TSPath " + pkg.version));
 		let args = process.argv.slice(2);
 		let param = args[0];
-		let filter = ["js"];
+		let filter = ["js", "jsx"];
 		let force: boolean = (yargs.force || yargs.f);
 		let projectPath = process.cwd();
 		let compactOutput = yargs.preserve ? false : true;


### PR DESCRIPTION
In current code, if the `dist` path includes `.d.ts` files or other things, a `Unexpected token` error may be thrown in parsing period. This PR enforces only `.js` files are included.