### PR TITLE
Make bin point at tspath.js not src/tspath.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "preferGlobal": true,
   "bin": {
-    "tspath": "./dist/src/tspath.js"
+    "tspath": "./dist/tspath.js"
   },
   "keywords": [
     "relative",


### PR DESCRIPTION
Because the files in src are not up-to-date.

You can test this out in a project with: `npm i --save-dev tspath`.

Then compare: `grep compact node_modules/tspath/src/parser-engine.js`.
```
let option = { comment: true, format: { compact: true, quotes: '"' } };
```

To: `grep compact node_modules/tspath/parser-engine.js`.
```
this.compactMode = true;
let option = { comment: true, format: { compact: this.compactMode, quotes: '"' } };
```

And finally check out which one bin points at: `grep -A 3 bin node_modules/tspath/package.json`.
```
  "bin": {
    "tspath": "src/tspath.js"
  },
```

**Thanks for the awesome tool - very much appreciated.**
